### PR TITLE
libalsap: makefile and debug related changes

### DIFF
--- a/build/agent/makefile
+++ b/build/agent/makefile
@@ -48,6 +48,12 @@ CXXFLAGS += $(INCLUDEDIRS) -g -DEASY_MESH_NODE -DEM_APP -Wall -Wextra -Wpointer-
 ifeq ($(WITH_SAP), 1)
 CXXFLAGS += -DAL_SAP
 endif
+
+ifeq ($(ENABLE_DEBUG_MODE),ON)
+$(info ENABLE_DEBUG_MODE is set)
+CXXFLAGS += -DDEBUG_MODE
+endif
+
 LDFLAGS += $(LIBDIRS) $(LIBS) -fsanitize=address -fsanitize=undefined
 
 LIBDIRS = \

--- a/build/ctrl/makefile
+++ b/build/ctrl/makefile
@@ -52,6 +52,11 @@ ifeq ($(WITH_SAP), 1)
 CXXFLAGS += -DAL_SAP
 endif
 
+ifeq ($(ENABLE_DEBUG_MODE),ON)
+$(info ENABLE_DEBUG_MODE is set)
+CXXFLAGS += -DDEBUG_MODE
+endif
+
 ifdef TESTING
 CXXFLAGS += -DTESTING
 endif

--- a/build/libalsap/makefile
+++ b/build/libalsap/makefile
@@ -13,7 +13,6 @@ RECEIVER_SRC = $(AL_SAP_HOME)/../../tests/test_libalsap_receiver.cpp
 TRANSMITTER = $(INSTALLDIR)/bin/test_alsap_transmitter
 RECEIVER = $(INSTALLDIR)/bin/test_alsap_receeiver
 
-ENABLE_DEBUG_MODE ?= ON
 ifeq ($(ENABLE_DEBUG_MODE),ON)
 $(info ENABLE_DEBUG_MODE is set)
 CPPFLAGS += -DDEBUG_MODE

--- a/build/makefile.inc
+++ b/build/makefile.inc
@@ -19,7 +19,8 @@
 OS = $(shell uname)
 PLATFORM = $(shell uname -a)
 
-WITH_SAP ?= 0
+WITH_SAP ?= 1
+ENABLE_DEBUG_MODE ?= ON
 
 BASE = $(shell pwd)
 


### PR DESCRIPTION
This commit contains changes related to libalsap:
1) makefile changes to enable/disable libalsap debug logs. 
2) resolve compilation warning in em controller related to libalsap.
3) resolve logging of src and dst macaddress of ieee1905 packet.